### PR TITLE
Fix broken link to SWE-bench config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -551,7 +551,7 @@ def parse_action(action: str) -> str:
 ### Environment variables
 
 There's a couple of environment variables that we can set to disable interactive
-elements in command line tools that avoid the agent getting stuck (you can see them being set in the [`mini-swe-agent` SWE-bench config](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/config/extra/swebench.yaml)):
+elements in command line tools that avoid the agent getting stuck (you can see them being set in the [`mini-swe-agent` SWE-bench config](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/config/benchmarks/swebench.yaml)):
 
 ```python
 env_vars = {


### PR DESCRIPTION
The link in the *Environment variables* section points to `src/minisweagent/config/extra/swebench.yaml`, which 404s: the file was moved to `src/minisweagent/config/benchmarks/swebench.yaml` in mini-swe-agent's January 2026 reorganization (commit "Change: Reorganize run scripts into benchmarks/").

Verified the new URL resolves and still contains the env vars shown in the tutorial (`PAGER: cat`, etc.).